### PR TITLE
Handle location conditionally based on availability

### DIFF
--- a/index.android.js
+++ b/index.android.js
@@ -89,7 +89,7 @@ setGPSTrigger = (interval) => {
     			lon: newestPosition.coords.longitude,
     			acc: newestPosition.coords.accuracy.toFixed(3),
     			alt: newestPosition.coords.altitude,
-    			time: moment(newestPosition.timestamp).format("YYYY-MM-DD-HH:mm:ss"),
+    			time: new Date(newestPosition.timestamp),
           provider: newestPosition.provider,
     		}
     		Utils.writeToFile(store, gps, FILE_TAG_GPS);

--- a/src/constants.js
+++ b/src/constants.js
@@ -52,11 +52,13 @@ export const GPS_OPTIONS = {
 	enableHighAccuracy: true,
 	timeout: 50000,
 	maximumAge: 0,
+	distanceFilter: 1,
 };
 export const SECONDARY_LOCATION_OPTIONS = {
 	enableHighAccuracy: false,
 	timeout: 50000,
 	maximumAge: 0,
+	distanceFilter: 1,
 };
 
 // https://www.bluetooth.com/specifications/assigned-numbers/service-discovery

--- a/src/constants.js
+++ b/src/constants.js
@@ -58,7 +58,6 @@ export const SECONDARY_LOCATION_OPTIONS = {
 	enableHighAccuracy: false,
 	timeout: 50000,
 	maximumAge: 0,
-	distanceFilter: 1,
 };
 
 // https://www.bluetooth.com/specifications/assigned-numbers/service-discovery


### PR DESCRIPTION
Due to inherent limitations in the React Native geolocation implementation we need 2 separate listeners for 1. GPS location 2. Cell/wifi location. These fixes intend to handle this so that GPS information has higher priority but coarse location is used if GPS location stops updating.